### PR TITLE
The input to qr is fixed.

### DIFF
--- a/gp/gpUpdateAD.m
+++ b/gp/gpUpdateAD.m
@@ -53,7 +53,7 @@ switch model.approx
     else
       Ruu = jitChol(model.K_uu);
       sqrtBeta = sqrt(model.beta);
-      [Q, R] = qr([Ruu; sqrt(model.beta)*model.K_uf'],  '0');
+      [Q, R] = qr([Ruu; sqrt(model.beta)*model.K_uf'],0);
       RA = 1/sqrtBeta*R;
       model.A = RA'*RA;
       model.Ainv = pdinv(model.A, RA);


### PR DESCRIPTION
Running demOilFgplvm7 demo results in the following error when calling fgplvmCreate.m:
```
Error using qr
Use qr(A,0) for economy size decomposition or use qr(A,'matrix') for a
permutation matrix and qr(A,'vector') for a permutation vector.

Error in gpUpdateAD (line 56)
      [Q, R] = qr([Ruu; sqrt(model.beta)*model.K_uf'],  '0');

Error in gpUpdateKernels (line 92)
model = gpUpdateAD(model, X);

Error in gpExpandParam (line 72)
  model = gpUpdateKernels(model, model.X, model.X_u);

Error in gpCreate (line 205)
model = gpExpandParam(model, initParams);

Error in fgplvmCreate (line 41)
model = gpCreate(q, d, X, Y, options);
```
This is because the second input to qr must be a either string with 'matrix' or 'vector' values, or scalar 0. While in the current version the input is string '0' (line 56 in gp/gpUpdateAD.m). 
This pull request simply resolves the bug by changing '0' to scalar 0.